### PR TITLE
[Nexus] initial release change for new Kodi 20 Nexus version

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,1 +1,1 @@
-buildPlugin(version: "Matrix")
+buildPlugin(version: "Nexus")

--- a/README.md
+++ b/README.md
@@ -3,10 +3,10 @@
 This is a [Kodi](https://kodi.tv) audio decoder addon for SSF and (mini-)DSF files.
 
 [![License: GPL-2.0-or-later](https://img.shields.io/badge/License-GPL%20v2+-blue.svg)](LICENSE.md)
-[![Build and run tests](https://github.com/xbmc/audiodecoder.ssf/actions/workflows/build.yml/badge.svg?branch=Matrix)](https://github.com/xbmc/audiodecoder.ssf/actions/workflows/build.yml)
-[![Build Status](https://dev.azure.com/teamkodi/binary-addons/_apis/build/status/xbmc.audiodecoder.ssf?branchName=Matrix)](https://dev.azure.com/teamkodi/binary-addons/_build/latest?definitionId=15&branchName=Matrix)
-[![Build Status](https://jenkins.kodi.tv/view/Addons/job/xbmc/job/audiodecoder.ssf/job/Matrix/badge/icon)](https://jenkins.kodi.tv/blue/organizations/jenkins/xbmc%2Faudiodecoder.ssf/branches/)
-<!--- [![Build Status](https://ci.appveyor.com/api/projects/status/github/xbmc/audiodecoder.ssf?branch=Matrix&svg=true)](https://ci.appveyor.com/project/xbmc/audiodecoder-ssf?branch=Matrix) -->
+[![Build and run tests](https://github.com/xbmc/audiodecoder.ssf/actions/workflows/build.yml/badge.svg?branch=Nexus)](https://github.com/xbmc/audiodecoder.ssf/actions/workflows/build.yml)
+[![Build Status](https://dev.azure.com/teamkodi/binary-addons/_apis/build/status/xbmc.audiodecoder.ssf?branchName=Nexus)](https://dev.azure.com/teamkodi/binary-addons/_build/latest?definitionId=15&branchName=Nexus)
+[![Build Status](https://jenkins.kodi.tv/view/Addons/job/xbmc/job/audiodecoder.ssf/job/Nexus/badge/icon)](https://jenkins.kodi.tv/blue/organizations/jenkins/xbmc%2Faudiodecoder.ssf/branches/)
+<!--- [![Build Status](https://ci.appveyor.com/api/projects/status/github/xbmc/audiodecoder.ssf?branch=Nexus&svg=true)](https://ci.appveyor.com/project/xbmc/audiodecoder-ssf?branch=Nexus) -->
 
 ## Build instructions
 

--- a/audiodecoder.ssf/addon.xml.in
+++ b/audiodecoder.ssf/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="audiodecoder.ssf"
-  version="3.0.0"
+  version="20.0.0"
   name="SSF/DSF Audio Decoder"
   provider-name="spiff">
   <requires>@ADDON_DEPENDS@</requires>

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -5,6 +5,7 @@ trigger:
   branches:
     include:
     - Matrix
+    - Nexus
     - releases/*
   paths:
     include:


### PR DESCRIPTION
This change the builds to Kodi Nexus.

Further is the version to 20.0.0 increased to have equal to Kodi and to see on which Version this addon works.